### PR TITLE
fix: 🐛 Component-id is replaced in exposed children prop

### DIFF
--- a/src/utils/recursive.ts
+++ b/src/utils/recursive.ts
@@ -147,7 +147,7 @@ export const fetchAndUpdateExposedProps = (
             name: prop.derivedFromPropName || '',
             value:
               prop.name === 'children' &&
-              (component.type === 'Box' || component.type === 'Flex')
+              (comp.type === 'Box' || comp.type === 'Flex')
                 ? 'RootCbComposer'
                 : prop.value,
             componentId: rootParentId,


### PR DESCRIPTION
When the children prop  of any component is exposed and then the
component is saved, the prop-value is replaced with the component-id of
the component.